### PR TITLE
Check permissions in translations overview using Permissions class

### DIFF
--- a/src/Controller/AllowedLanguagesController.php
+++ b/src/Controller/AllowedLanguagesController.php
@@ -31,14 +31,10 @@ class AllowedLanguagesController extends ContentTranslationController {
     $bundle_id = $entity->bundle();
     // Map with operations add = "create", edit = "", delete = "delete".
     // Empty value is edit translate.
-    $permissions = ["add" => "cta create translation", "edit" => "cta translate", "delete" => "cta delete translation"];
+    $permissions = ['add' => 'create', 'edit' => 'update', 'delete' => 'delete'];
 
     foreach ($permissions as $operation => $permission) {
-      // Cta create translation node article
-      // cta delete translation node article
-      // cta translate node article.
-      $operation_name = $operation == 'add' ? 'create' : $operation;
-      $allow_operations[$operation] = Permissions::hasPermission($operation_name, $entity_type_id, $bundle_id, $user);
+      $allow_operations[$operation] = Permissions::hasPermission($permission, $entity_type_id, $bundle_id, $user);
     }
 
     if (!$user->hasPermission('translate all languages') && $user_entity->hasRole("local_editor") && !empty($build['content_translation_overview']['#rows'])) {

--- a/src/Controller/AllowedLanguagesController.php
+++ b/src/Controller/AllowedLanguagesController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\content_translation_access\Controller;
 
+use Drupal\content_translation_access\Permissions;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\content_translation\Controller\ContentTranslationController;
 use Drupal\user\Entity\User;
@@ -36,8 +37,8 @@ class AllowedLanguagesController extends ContentTranslationController {
       // Cta create translation node article
       // cta delete translation node article
       // cta translate node article.
-      $permission .= " $entity_type_id $bundle_id";
-      $allow_operations[$operation] = $user_entity->hasPermission($permission);
+      $operation_name = $operation == 'add' ? 'create' : $operation;
+      $allow_operations[$operation] = Permissions::hasPermission($operation_name, $entity_type_id, $bundle_id, $user);
     }
 
     if (!$user->hasPermission('translate all languages') && $user_entity->hasRole("local_editor") && !empty($build['content_translation_overview']['#rows'])) {


### PR DESCRIPTION
Instead of checking the permissions by the hasPermission method of UserInterface, it would be better to call the Permissions class as it handle all the logic provided by this module.